### PR TITLE
Add -needs- arguments to build-and-push-container job

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -69,9 +69,9 @@ jobs:
 
   build-and-push-container:
     runs-on: ubuntu-latest
-    # needs: test  # Ensure this runs after the test job is completed
-    # needs: snyk-analysis  # Ensure this runs after the Snyk analysis is completed
-    # if: github.ref == 'refs/heads/main' -> if main wasn't specified above
+    needs: test  # Ensure this runs after the test job is completed
+    needs: snyk-analysis  # Ensure this runs after the Snyk analysis is completed
+    if: github.ref == 'refs/heads/main' -> if main wasn't specified above
     
     steps:
     - name: Checkout repository
@@ -81,7 +81,6 @@ jobs:
       run: |
         echo "REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
         echo "REPO_NAME=$(echo ${GITHUB_REPOSITORY#*/} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
 
     - name: Log in to GitHub Container Registry
       env:


### PR DESCRIPTION
This commit and branch changes the workflow so that a new image is built and pushed only after the tests and snyk analysis have been performed.