### PR TITLE
Continous Deployment with Skopeo to google cloud run

### DIFF
--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -114,7 +114,7 @@ jobs:
       run: |
         # Log in to GitHub Container Registry
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-        
+
         # Sync the image
         gcloud auth configure-docker europe-west3-docker.pkg.dev
         skopeo sync \
@@ -129,7 +129,7 @@ jobs:
       uses: 'google-github-actions/deploy-cloudrun@v2'
       with:
         service: 'note-api-hs-heilbronn-devsecops-group-tnm'
-        image: 'europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}'
+        image: 'europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}'
         region: 'europe-west3'
         env_vars: |-
           BACKEND=memory

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -117,6 +117,7 @@ jobs:
 
         # Copy the image
         skopeo copy \
+          --dest-registry-token "${{ steps.google-auth.outputs.access_token }}" \
           --dest-compress \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -107,25 +107,23 @@ jobs:
         sudo apt-get install -y skopeo
 
     - name: Copy Image to Google Artifact Registry
-      env:
-        PROJECT_ID: ${{ needs.envs.outputs.grc_project_id }}
-        ARTIFACTORY_REPO: ${{ needs.envs.outputs.grc_artifactory_repo }}
       run: |
         # Authenticate and retrieve an access token
         ACCESS_TOKEN=$(gcloud auth print-access-token)
+        echo "${ACCESS_TOKEN}"
+        echo "${{ ACCESS_TOKEN }}"
 
         # Copy the image
-        skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
+        skopeo copy --dest-creds="${{ACCESS_TOKEN}}:" \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
-          docker://europe-west3-docker.pkg.dev/${PROJECT_ID}/${ARTIFACTORY_REPO}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
-
+          docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
 
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v2'
       with:
         service: 'note-api-hs-heilbronn-devsecops-group-tnm'
         #image: 'ghcr.io/hs-heilbronn-devsecops-group-tnm/note-api:main-release-2024-11-21-sha-442db75' # Old version
-        image: 'europe-west3-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.ARTIFACTORY_REPO }}/note-api:${{ needs.envs.outputs.tag }}'
+        image: 'europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/note-api:${{ needs.envs.outputs.tag }}'
         region: 'europe-west3'
         env_vars: |-
           BACKEND=memory

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -116,12 +116,18 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
         # Copy the image
-        skopeo copy \
-          --debug \
-          --dest-registry-token "${{ steps.google-auth.outputs.access_token }}" \
-          docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
-          docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
-          #docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
+        #skopeo copy \
+        #  --debug \
+        #  --dest-registry-token "${{ steps.google-auth.outputs.access_token }}" \
+        #  docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
+        #  docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
+        #  #docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
+
+        # Sync the image
+        gcloud auth configure-docker europe-west3-docker.pkg.dev
+        skopeo sync
+          --src docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
+          --dest docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
 
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v2'

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -117,6 +117,7 @@ jobs:
 
         # Copy the image
         skopeo copy \
+          --debug \
           --dest-registry-token "${{ steps.google-auth.outputs.access_token }}" \
           --dest-compress \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -114,15 +114,7 @@ jobs:
       run: |
         # Log in to GitHub Container Registry
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-        # Copy the image
-        #skopeo copy \
-        #  --debug \
-        #  --dest-registry-token "${{ steps.google-auth.outputs.access_token }}" \
-        #  docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
-        #  docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
-        #  #docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
-
+        
         # Sync the image
         gcloud auth configure-docker europe-west3-docker.pkg.dev
         skopeo sync \
@@ -133,13 +125,11 @@ jobs:
           ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/
 
-
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v2'
       with:
         service: 'note-api-hs-heilbronn-devsecops-group-tnm'
-        #image: 'ghcr.io/hs-heilbronn-devsecops-group-tnm/note-api:main-release-2024-11-21-sha-442db75' # Old version
-        image: 'europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/note-api:${{ needs.envs.outputs.tag }}'
+        image: 'europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}'
         region: 'europe-west3'
         env_vars: |-
           BACKEND=memory

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -119,11 +119,9 @@ jobs:
         skopeo copy \
           --debug \
           --dest-registry-token "${{ steps.google-auth.outputs.access_token }}" \
-          --dest-compress \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
           #docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
-
 
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v2'

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -87,7 +87,7 @@ jobs:
 
   deploy-to-google-cloud-run:
     runs-on: ubuntu-latest
-    needs: build-and-push-container
+    needs: [build-and-push-container, envs]
 
     permissions:
       contents: 'read'
@@ -108,8 +108,8 @@ jobs:
 
     - name: Copy Image to Google Artifact Registry
       env:
-        PROJECT_ID: ${{ env.PROJECT_ID }}
-        ARTIFACTORY_REPO: ${{ env.ARTIFACTORY_REPO }}
+        PROJECT_ID: ${{ needs.envs.outputs.grc_project_id }}
+        ARTIFACTORY_REPO: ${{ needs.envs.outputs.grc_artifactory_repo }}
       run: |
         # Authenticate and retrieve an access token
         ACCESS_TOKEN=$(gcloud auth print-access-token)

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -118,7 +118,7 @@ jobs:
         ACCESS_TOKEN=$(gcloud auth print-access-token)
 
         # Copy the image
-        skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
+        skopeo copy \ #--dest-creds="${ACCESS_TOKEN}:" \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:main-release-2024-11-27-sha-7d18070
           # original docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -100,6 +100,12 @@ jobs:
       with:
         workload_identity_provider: 'projects/70756149774/locations/global/workloadIdentityPools/github-actions/providers/github-repos'
         service_account: 'hshn-devsecops-service-account@hs-heilbronn-devsecops.iam.gserviceaccount.com'
+    
+    - name: Log in to GitHub Container Registry
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      shell: bash
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
     - name: Install Skopeo
       run: |
@@ -110,7 +116,6 @@ jobs:
       run: |
         # Authenticate and retrieve an access token
         ACCESS_TOKEN=$(gcloud auth print-access-token)
-        echo "${ACCESS_TOKEN}"
 
         # Copy the image
         skopeo copy --dest-creds="${ACCESS_TOKEN}:" \

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -115,7 +115,8 @@ jobs:
         # Copy the image
         skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
-          docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
+          docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm:note-api:main-release-2024-11-27-sha-7d18070
+          # original docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
 
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v2'

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -18,6 +18,8 @@ jobs:
       repo_owner: ${{ steps.set-env.outputs.repo_owner }}
       repo_name: ${{ steps.set-env.outputs.repo_name }}
       tag: ${{ steps.set-tag.outputs.tag }}
+      grc_project_id: ${{ steps.set-project-id.outputs.grc_project_id }}
+      grc_artifactory_repo: ${{ steps.set-project-id.outputs.grc_artifactory_repo }}
     permissions:
       contents: read  # Required to read repository metadata
     steps:
@@ -51,6 +53,12 @@ jobs:
           echo "tag=main-release-${{ steps.date.outputs.date }}-sha-${{ env.COMMIT_HASH_SHORT }}" >> $GITHUB_ENV
           echo "::set-output name=tag::main-release-${{ steps.date.outputs.date }}-sha-${{ env.COMMIT_HASH_SHORT }}"
         fi
+    - name: Set Project ID and Artifact Registry Repository Name
+      shell: bash
+      run: |
+        echo "GRC_PROJECT_ID=hs-heilbronn-devsecops" >> $GITHUB_ENV
+        echo "GRC_ARTIFACTORY_REPO=note-api-hs-heilbronn-devsecops-group-tnm" >> $GITHUB_ENV
+
 
   build-and-push-container:
     runs-on: ubuntu-latest
@@ -91,12 +99,30 @@ jobs:
         workload_identity_provider: 'projects/70756149774/locations/global/workloadIdentityPools/github-actions/providers/github-repos'
         service_account: 'hshn-devsecops-service-account@hs-heilbronn-devsecops.iam.gserviceaccount.com'
 
+    - name: Install Skopeo
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y skopeo
+
+    - name: Copy Image to Google Artifact Registry
+      env:
+        GCP_KEY_FILE: ${{ secrets.GCP_KEY_FILE }}
+        PROJECT_ID: ${{ env.PROJECT_ID }}
+        ARTIFACTORY_REPO: ${{ env.ARTIFACTORY_REPO }}
+      run: |
+        echo "${GCP_KEY_FILE}" > keyfile.json
+        gcloud auth activate-service-account --key-file=keyfile.json
+        skopeo copy --dest-creds="$(gcloud auth print-access-token):" \
+          docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
+          docker://europe-west3-docker.pkg.dev/${PROJECT_ID}/${ARTIFACTORY_REPO}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
+
 
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v2'
       with:
         service: 'note-api-hs-heilbronn-devsecops-group-tnm'
-        image: 'ghcr.io/hs-heilbronn-devsecops-group-tnm/note-api:main-release-2024-11-21-sha-442db75'
+        #image: 'ghcr.io/hs-heilbronn-devsecops-group-tnm/note-api:main-release-2024-11-21-sha-442db75' # Old version
+        image: 'europe-west3-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.ARTIFACTORY_REPO }}/note-api:${{ needs.envs.outputs.tag }}'
         region: 'europe-west3'
         env_vars: |-
           BACKEND=memory

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -54,6 +54,7 @@ jobs:
           echo "::set-output name=tag::main-release-${{ steps.date.outputs.date }}-sha-${{ env.COMMIT_HASH_SHORT }}"
         fi
     - name: Set Project ID and Artifact Registry Repository Name
+      id: set-project-id
       shell: bash
       run: |
         echo "GRC_PROJECT_ID=hs-heilbronn-devsecops" >> $GITHUB_ENV
@@ -63,7 +64,7 @@ jobs:
   build-and-push-container:
     runs-on: ubuntu-latest
     needs: envs  # Depends on envs job to access its outputs
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success' }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -125,9 +125,14 @@ jobs:
 
         # Sync the image
         gcloud auth configure-docker europe-west3-docker.pkg.dev
-        skopeo sync
-          --src docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
-          --dest docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
+        skopeo sync \
+          --debug \
+          --src docker \
+          --dest docker \
+          --dest-registry-token "${{ steps.google-auth.outputs.access_token }}" \
+          ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
+          europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
+
 
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v2'

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -114,6 +114,7 @@ jobs:
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
         # Authenticate and retrieve an access token
+        gcloud auth print-access-token
         ACCESS_TOKEN=$(gcloud auth print-access-token)
 
         # Copy the image

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -98,8 +98,11 @@ jobs:
     - uses: 'actions/checkout@v4'
 
     - uses: 'google-github-actions/auth@v2'
+      id: 'google-auth'
       with:
         workload_identity_provider: 'projects/70756149774/locations/global/workloadIdentityPools/github-actions/providers/github-repos'
+        service_account: 'hshn-devsecops-service-account@hs-heilbronn-devsecops.iam.gserviceaccount.com'
+        token_format: 'access_token'
 
     - name: Install Skopeo
       run: |
@@ -113,13 +116,9 @@ jobs:
         # Log in to GitHub Container Registry
         echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-        # Authenticate and retrieve an access token
-        gcloud auth print-access-token
-        ACCESS_TOKEN=$(gcloud auth print-access-token)
-
         # Copy the image
         skopeo copy \
-          --dest-creds="${ACCESS_TOKEN}:" \
+          --dest-creds="${{ steps.google-auth.outputs.access_token }}:" \
           --dest-compress \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -115,7 +115,7 @@ jobs:
         # Copy the image
         skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
-          docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm:note-api:main-release-2024-11-27-sha-7d18070
+          docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:main-release-2024-11-27-sha-7d18070
           # original docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
 
     - id: 'deploy'

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -113,12 +113,18 @@ jobs:
         sudo apt-get install -y skopeo
 
     - name: Copy Image to Google Artifact Registry
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        # Log in to GitHub Container Registry
+        echo "${{ secrets.GITHUB_TOKEN }}"
+        docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
         # Authenticate and retrieve an access token
         ACCESS_TOKEN=$(gcloud auth print-access-token)
 
         # Copy the image
-        skopeo copy \ #--dest-creds="${ACCESS_TOKEN}:" \
+        skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:main-release-2024-11-27-sha-7d18070
           # original docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -111,10 +111,9 @@ jobs:
         # Authenticate and retrieve an access token
         ACCESS_TOKEN=$(gcloud auth print-access-token)
         echo "${ACCESS_TOKEN}"
-        echo "${{ ACCESS_TOKEN }}"
 
         # Copy the image
-        skopeo copy --dest-creds="${{ACCESS_TOKEN}}:" \
+        skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
 

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -117,10 +117,13 @@ jobs:
         ACCESS_TOKEN=$(gcloud auth print-access-token)
 
         # Copy the image
-        skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
+        skopeo copy \
+          --dest-creds="${ACCESS_TOKEN}:" \
+          --dest-compress \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
-          docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
-          # original docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
+          docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
+          #docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
+
 
     - id: 'deploy'
       uses: 'google-github-actions/deploy-cloudrun@v2'

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -92,6 +92,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      packages: 'read'
 
     steps:
     - uses: 'actions/checkout@v4'
@@ -118,7 +119,7 @@ jobs:
         # Copy the image
         skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
-          docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:main-release-2024-11-27-sha-7d18070
+          docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/cloud-run-source-deploy/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
           # original docker://europe-west3-docker.pkg.dev/${{ needs.envs.outputs.grc_project_id }}/${{ needs.envs.outputs.grc_artifactory_repo }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
 
     - id: 'deploy'

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -102,7 +102,6 @@ jobs:
       with:
         workload_identity_provider: 'projects/70756149774/locations/global/workloadIdentityPools/github-actions/providers/github-repos'
         service_account: 'hshn-devsecops-service-account@hs-heilbronn-devsecops.iam.gserviceaccount.com'
-        token_format: 'access_token'
 
     - name: Install Skopeo
       run: |
@@ -118,7 +117,6 @@ jobs:
 
         # Copy the image
         skopeo copy \
-          --dest-creds="${{ steps.google-auth.outputs.access_token }}:" \
           --dest-compress \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           docker://europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -108,13 +108,14 @@ jobs:
 
     - name: Copy Image to Google Artifact Registry
       env:
-        GCP_KEY_FILE: ${{ secrets.GCP_KEY_FILE }}
         PROJECT_ID: ${{ env.PROJECT_ID }}
         ARTIFACTORY_REPO: ${{ env.ARTIFACTORY_REPO }}
       run: |
-        echo "${GCP_KEY_FILE}" > keyfile.json
-        gcloud auth activate-service-account --key-file=keyfile.json
-        skopeo copy --dest-creds="$(gcloud auth print-access-token):" \
+        # Authenticate and retrieve an access token
+        ACCESS_TOKEN=$(gcloud auth print-access-token)
+
+        # Copy the image
+        skopeo copy --dest-creds="${ACCESS_TOKEN}:" \
           docker://ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
           docker://europe-west3-docker.pkg.dev/${PROJECT_ID}/${ARTIFACTORY_REPO}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }}
 

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -57,14 +57,15 @@ jobs:
       id: set-project-id
       shell: bash
       run: |
-        echo "GRC_PROJECT_ID=hs-heilbronn-devsecops" >> $GITHUB_ENV
-        echo "GRC_ARTIFACTORY_REPO=note-api-hs-heilbronn-devsecops-group-tnm" >> $GITHUB_ENV
+        echo "grc_project_id=hs-heilbronn-devsecops" >> $GITHUB_ENV
+        echo "grc_artifactory_repo=note-api-hs-heilbronn-devsecops-group-tnm" >> $GITHUB_ENV
 
 
   build-and-push-container:
     runs-on: ubuntu-latest
-    needs: envs  # Depends on envs job to access its outputs
-    if: ${{ github.event_name != 'workflow_dispatch' && github.event.workflow_run.conclusion == 'success' }}
+    needs: envs  
+
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -99,13 +99,6 @@ jobs:
     - uses: 'google-github-actions/auth@v2'
       with:
         workload_identity_provider: 'projects/70756149774/locations/global/workloadIdentityPools/github-actions/providers/github-repos'
-        service_account: 'hshn-devsecops-service-account@hs-heilbronn-devsecops.iam.gserviceaccount.com'
-    
-    - name: Log in to GitHub Container Registry
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      shell: bash
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
     - name: Install Skopeo
       run: |
@@ -117,8 +110,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # Log in to GitHub Container Registry
-        echo "${{ secrets.GITHUB_TOKEN }}"
-        docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
         # Authenticate and retrieve an access token
         ACCESS_TOKEN=$(gcloud auth print-access-token)

--- a/.github/workflows/container-build-push-deploy.yml
+++ b/.github/workflows/container-build-push-deploy.yml
@@ -131,7 +131,7 @@ jobs:
           --dest docker \
           --dest-registry-token "${{ steps.google-auth.outputs.access_token }}" \
           ghcr.io/${{ needs.envs.outputs.repo_owner }}/${{ needs.envs.outputs.repo_name }}:${{ needs.envs.outputs.tag }} \
-          europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/note-api:${{ needs.envs.outputs.tag }}
+          europe-west3-docker.pkg.dev/hs-heilbronn-devsecops/note-api-hs-heilbronn-devsecops-group-tnm/
 
 
     - id: 'deploy'


### PR DESCRIPTION
The deployment did not work because the github container registry is not available from google cloud run for service applications.

Therefore, after a successful container build and push to the github registry, skopeo is used to copy the container to the artifactory registry of google or the sync function of skopeo is used, as this has caused fewer problems and logically does the same thing.